### PR TITLE
Update event schemas and align tests/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -626,6 +626,8 @@ All events emitted by the registry and asset contracts. Use for indexing, loggin
   - `uint256 indexed endTime` : Subscription expiry time (Unix timestamp).
   - `uint256 nonce` : Subscription nonce (increments each time a new record is created for the subscriber).
   - `address payer` : Payer for this subscription (refund beneficiary on cancel/revoke).
+  - `uint256 subscriptionPrice` : Per-second subscription price snapshot used for this subscription record.
+  - `uint256 registryFeeShare` : Registry fee share snapshot (0-100) used for this subscription record.
 
 
 ---
@@ -644,6 +646,15 @@ All events emitted by the registry and asset contracts. Use for indexing, loggin
 - Parameters:
   - `bytes32 indexed subscriber` : Subscriber whose creator fee was claimed.
   - `uint256 amount` : Amount of creator fee claimed.
+
+
+---
+
+**CreatorFeeClaimedBatch** : Emitted when creator fees are claimed for multiple subscribers in a single batch call. Emitted once per batch call regardless of how many subscribers had claimable fees.
+- Contract: `Asset`
+- Parameters:
+  - `bytes32[] indexed subscribers` : Array of subscriber identities passed to the batch claim (note: as an indexed dynamic type, the topic is the keccak256 hash of the ABI-encoded array).
+  - `uint256 totalAmount` : Total creator fee claimed across all subscribers in the batch.
 
 
 ---

--- a/src/Asset.sol
+++ b/src/Asset.sol
@@ -63,10 +63,12 @@ contract Asset is Ownable, ReentrancyGuard, IAsset {
     error OnlyRegistryUnauthorizedAccount();
 
     event SubscriptionAdded(
-        bytes32 indexed subscriber, uint256 indexed startTime, uint256 indexed endTime, uint256 nonce, address payer
+        bytes32 indexed subscriber, uint256 indexed startTime, uint256 indexed endTime, uint256 nonce, address payer, 
+        uint256 subscriptionPrice, uint256 registryFeeShare
     );
     event SubscriptionExtended(bytes32 indexed subscriber, uint256 indexed endTime);
     event CreatorFeeClaimed(bytes32 indexed subscriber, uint256 amount);
+    event CreatorFeeClaimedBatch(bytes32[] indexed subscribers, uint256 totalAmount);
     event SubscriptionPriceUpdated(uint256 newSubscriptionPrice);
     event SubscriptionRevoked(bytes32 indexed subscriber);
     event SubscriptionCancelled(bytes32 indexed subscriber);
@@ -208,7 +210,7 @@ contract Asset is Ownable, ReentrancyGuard, IAsset {
 
         subscribers.add(subscriber);
 
-        emit SubscriptionAdded(subscriber, startTime, endTime, nonce, payer);
+        emit SubscriptionAdded(subscriber, startTime, endTime, nonce, payer, subscriptionPrice, registryFeeShare);
 
         return endTime;
     }
@@ -351,6 +353,8 @@ contract Asset is Ownable, ReentrancyGuard, IAsset {
         if (claimed != 0) {
             SafeERC20.safeTransfer(TOKEN_CONTRACT, owner(), claimed);
         }
+
+        emit CreatorFeeClaimedBatch(_subscribers, claimed);
 
         return claimed;
     }

--- a/src/Asset.sol
+++ b/src/Asset.sol
@@ -63,8 +63,13 @@ contract Asset is Ownable, ReentrancyGuard, IAsset {
     error OnlyRegistryUnauthorizedAccount();
 
     event SubscriptionAdded(
-        bytes32 indexed subscriber, uint256 indexed startTime, uint256 indexed endTime, uint256 nonce, address payer, 
-        uint256 subscriptionPrice, uint256 registryFeeShare
+        bytes32 indexed subscriber,
+        uint256 indexed startTime,
+        uint256 indexed endTime,
+        uint256 nonce,
+        address payer,
+        uint256 subscriptionPrice,
+        uint256 registryFeeShare
     );
     event SubscriptionExtended(bytes32 indexed subscriber, uint256 indexed endTime);
     event CreatorFeeClaimed(bytes32 indexed subscriber, uint256 amount);

--- a/src/AssetRegistry.sol
+++ b/src/AssetRegistry.sol
@@ -37,6 +37,8 @@ contract AssetRegistry is Ownable, IAssetRegistry {
         }
 
         registryFeeShare = _registryFeeShare;
+
+        emit RegistryFeeShareUpdated(registryFeeShare);
     }
 
     function createAsset(bytes32 _assetId, uint256 _subscriptionPrice, address _tokenAddress, address _owner)

--- a/test/Asset.t.sol
+++ b/test/Asset.t.sol
@@ -119,7 +119,13 @@ contract AssetTest is BaseTest {
             vm.expectEmit(true, true, true, true);
             if (i == 0) {
                 emit Asset.SubscriptionAdded(
-                    SUBSCRIBER, deadline, deadline + DURATION, i, signer, SUBSCRIPTION_PRICE, assetRegistry.getRegistryFeeShare()
+                    SUBSCRIBER,
+                    deadline,
+                    deadline + DURATION,
+                    i,
+                    signer,
+                    SUBSCRIPTION_PRICE,
+                    assetRegistry.getRegistryFeeShare()
                 );
             } else {
                 emit Asset.SubscriptionExtended(SUBSCRIBER, deadline + DURATION);
@@ -1185,13 +1191,7 @@ contract AssetTest is BaseTest {
         uint256 newEnd = block.timestamp + DURATION;
         vm.expectEmit(true, true, true, true);
         emit Asset.SubscriptionAdded(
-            SUBSCRIBER,
-            block.timestamp,
-            newEnd,
-            1,
-            signer,
-            SUBSCRIPTION_PRICE,
-            assetRegistry.getRegistryFeeShare()
+            SUBSCRIBER, block.timestamp, newEnd, 1, signer, SUBSCRIPTION_PRICE, assetRegistry.getRegistryFeeShare()
         );
         uint256 returnedEnd = _subscribe(DURATION);
 

--- a/test/Asset.t.sol
+++ b/test/Asset.t.sol
@@ -86,7 +86,15 @@ contract AssetTest is BaseTest {
         uint256 assetBalanceBefore = testToken.balanceOf(address(asset));
 
         vm.expectEmit(true, true, true, true);
-        emit Asset.SubscriptionAdded(SUBSCRIBER, block.timestamp, block.timestamp + DURATION, 0, signer);
+        emit Asset.SubscriptionAdded(
+            SUBSCRIBER,
+            block.timestamp,
+            block.timestamp + DURATION,
+            0,
+            signer,
+            SUBSCRIPTION_PRICE,
+            assetRegistry.getRegistryFeeShare()
+        );
 
         uint256 subscription = _subscribe(DURATION);
 
@@ -110,7 +118,9 @@ contract AssetTest is BaseTest {
         for (uint256 i = 0; i < count; i++) {
             vm.expectEmit(true, true, true, true);
             if (i == 0) {
-                emit Asset.SubscriptionAdded(SUBSCRIBER, deadline, deadline + DURATION, i, signer);
+                emit Asset.SubscriptionAdded(
+                    SUBSCRIBER, deadline, deadline + DURATION, i, signer, SUBSCRIPTION_PRICE, assetRegistry.getRegistryFeeShare()
+                );
             } else {
                 emit Asset.SubscriptionExtended(SUBSCRIBER, deadline + DURATION);
             }
@@ -916,7 +926,15 @@ contract AssetTest is BaseTest {
 
     function test_subscribe_newNonce_differentPrice() public {
         vm.expectEmit(true, true, true, true);
-        emit Asset.SubscriptionAdded(SUBSCRIBER, block.timestamp, block.timestamp + DURATION, 0, signer);
+        emit Asset.SubscriptionAdded(
+            SUBSCRIBER,
+            block.timestamp,
+            block.timestamp + DURATION,
+            0,
+            signer,
+            SUBSCRIPTION_PRICE,
+            assetRegistry.getRegistryFeeShare()
+        );
         _subscribe(DURATION);
 
         vm.prank(assetOwner);
@@ -924,13 +942,29 @@ contract AssetTest is BaseTest {
 
         uint256 newStart = block.timestamp + DURATION;
         vm.expectEmit(true, true, true, true);
-        emit Asset.SubscriptionAdded(SUBSCRIBER, newStart, newStart + DURATION, 1, signer);
+        emit Asset.SubscriptionAdded(
+            SUBSCRIBER,
+            newStart,
+            newStart + DURATION,
+            1,
+            signer,
+            SUBSCRIPTION_PRICE * 2,
+            assetRegistry.getRegistryFeeShare()
+        );
         _subscribe(DURATION);
     }
 
     function test_subscribe_newNonce_feeShareChanged() public {
         vm.expectEmit(true, true, true, true);
-        emit Asset.SubscriptionAdded(SUBSCRIBER, block.timestamp, block.timestamp + DURATION, 0, signer);
+        emit Asset.SubscriptionAdded(
+            SUBSCRIBER,
+            block.timestamp,
+            block.timestamp + DURATION,
+            0,
+            signer,
+            SUBSCRIPTION_PRICE,
+            assetRegistry.getRegistryFeeShare()
+        );
         _subscribe(DURATION);
 
         vm.prank(registryOwner);
@@ -938,13 +972,21 @@ contract AssetTest is BaseTest {
 
         uint256 newStart = block.timestamp + DURATION;
         vm.expectEmit(true, true, true, true);
-        emit Asset.SubscriptionAdded(SUBSCRIBER, newStart, newStart + DURATION, 1, signer);
+        emit Asset.SubscriptionAdded(SUBSCRIBER, newStart, newStart + DURATION, 1, signer, SUBSCRIPTION_PRICE, 50);
         _subscribe(DURATION);
     }
 
     function test_subscribe_newNonce_differentPayer() public {
         vm.expectEmit(true, true, true, true);
-        emit Asset.SubscriptionAdded(SUBSCRIBER, block.timestamp, block.timestamp + DURATION, 0, signer);
+        emit Asset.SubscriptionAdded(
+            SUBSCRIBER,
+            block.timestamp,
+            block.timestamp + DURATION,
+            0,
+            signer,
+            SUBSCRIPTION_PRICE,
+            assetRegistry.getRegistryFeeShare()
+        );
         _subscribe(DURATION);
 
         uint256 key2 = vm.deriveKey(MNEMONIC, 1);
@@ -960,7 +1002,15 @@ contract AssetTest is BaseTest {
 
         uint256 newStart = block.timestamp + DURATION;
         vm.expectEmit(true, true, true, true);
-        emit Asset.SubscriptionAdded(SUBSCRIBER, newStart, newStart + DURATION, 1, payer2);
+        emit Asset.SubscriptionAdded(
+            SUBSCRIBER,
+            newStart,
+            newStart + DURATION,
+            1,
+            payer2,
+            SUBSCRIPTION_PRICE,
+            assetRegistry.getRegistryFeeShare()
+        );
         asset.subscribe(SUBSCRIBER, payer2, address(asset), value, deadline, v, r, s);
     }
 
@@ -986,6 +1036,8 @@ contract AssetTest is BaseTest {
         emit Asset.CreatorFeeClaimed(SUBSCRIBER, creatorFeePerSubscriber);
         vm.expectEmit(true, true, true, true);
         emit Asset.CreatorFeeClaimed(subscriber2, creatorFeePerSubscriber);
+        vm.expectEmit(true, true, true, true);
+        emit Asset.CreatorFeeClaimedBatch(subs, creatorFeePerSubscriber * 2);
         uint256 claimed = asset.claimCreatorFee(subs);
         vm.stopPrank();
 
@@ -1132,7 +1184,15 @@ contract AssetTest is BaseTest {
         // startTime (block.timestamp) != subscription.endTime, so no in-place extension occurs.
         uint256 newEnd = block.timestamp + DURATION;
         vm.expectEmit(true, true, true, true);
-        emit Asset.SubscriptionAdded(SUBSCRIBER, block.timestamp, newEnd, 1, signer);
+        emit Asset.SubscriptionAdded(
+            SUBSCRIBER,
+            block.timestamp,
+            newEnd,
+            1,
+            signer,
+            SUBSCRIPTION_PRICE,
+            assetRegistry.getRegistryFeeShare()
+        );
         uint256 returnedEnd = _subscribe(DURATION);
 
         assertEq(returnedEnd, newEnd);

--- a/test/AssetRegistry.t.sol
+++ b/test/AssetRegistry.t.sol
@@ -557,13 +557,7 @@ contract AssetRegistryTest is BaseTest {
         uint256 newEnd = block.timestamp + DURATION;
         vm.expectEmit(true, true, true, true);
         emit Asset.SubscriptionAdded(
-            SUBSCRIBER,
-            block.timestamp,
-            newEnd,
-            1,
-            signer,
-            SUBSCRIPTION_PRICE,
-            assetRegistry.getRegistryFeeShare()
+            SUBSCRIBER, block.timestamp, newEnd, 1, signer, SUBSCRIPTION_PRICE, assetRegistry.getRegistryFeeShare()
         );
         _subscribe(DURATION);
 

--- a/test/AssetRegistry.t.sol
+++ b/test/AssetRegistry.t.sol
@@ -556,7 +556,15 @@ contract AssetRegistryTest is BaseTest {
         // Re-subscribe with same terms after expiry — should produce a new nonce, not extend.
         uint256 newEnd = block.timestamp + DURATION;
         vm.expectEmit(true, true, true, true);
-        emit Asset.SubscriptionAdded(SUBSCRIBER, block.timestamp, newEnd, 1, signer);
+        emit Asset.SubscriptionAdded(
+            SUBSCRIBER,
+            block.timestamp,
+            newEnd,
+            1,
+            signer,
+            SUBSCRIPTION_PRICE,
+            assetRegistry.getRegistryFeeShare()
+        );
         _subscribe(DURATION);
 
         assertEq(assetRegistry.getSubscription(ASSET_ID, SUBSCRIBER), newEnd);


### PR DESCRIPTION
## Summary
- extend `Asset.SubscriptionAdded` with `subscriptionPrice` and `registryFeeShare` and emit `CreatorFeeClaimedBatch`
- emit `RegistryFeeShareUpdated` from `AssetRegistry` constructor for initialization visibility
- update `Asset` and `AssetRegistry` tests to match event signature changes and add batch event emit coverage
- refresh README event schema docs for the new/updated events

## Test plan
- [x] `forge test --match-contract AssetTest`
- [x] `forge test --match-contract AssetRegistryTest`

Made with [Cursor](https://cursor.com)