### PR TITLE
Add claimed timestamp/nonce event metadata and align tests/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,9 @@ All external functions for the registry and asset contracts, for use with JSON-R
   - `bytes32 _subscriber` : Hash of the subscriber identity whose registry fee to claim.
 - Returns:
   - `uint256` : Amount of registry fee claimed.
+- Notes:
+  - Emits `RegistryFeeClaimed(assetId, subscriber, amount, claimedAtTimestamp, claimedAtNonce)`.
+  - `claimedAtTimestamp` and `claimedAtNonce` are sourced from the underlying asset claim cursor.
 
 
 ---
@@ -382,7 +385,21 @@ All external functions for the registry and asset contracts, for use with JSON-R
   - `bytes32 _assetId` : Asset identifier.
   - `bytes32[] _subscribers` : Array of subscriber identity hashes to claim for.
 - Returns:
-  - `uint256` : Total amount of registry fee claimed across all subscribers.
+  - `uint256 totalClaimedAmount` : Total amount of registry fee claimed across all subscribers.
+
+
+---
+
+**emitRegistryFeeClaimedEvent** : Emits `RegistryFeeClaimed` for a single subscriber claim cursor update. Intended for calls from the corresponding Asset contract.
+- Type: write (event emission)
+- Permission: only the deployed asset for `_assetId`
+- Parameters:
+  - `bytes32 _assetId` : Asset identifier.
+  - `bytes32 _subscriber` : Subscriber identity hash.
+  - `uint256 claimedAmount` : Amount claimed for this subscriber.
+  - `uint256 claimedAtTimestamp` : Timestamp used as upper claim bound.
+  - `uint256 claimedAtNonce` : Subscription nonce reached while computing the claim.
+- Returns: void
 
 
 ---
@@ -498,7 +515,7 @@ All external functions for the registry and asset contracts, for use with JSON-R
 - Parameters:
   - `bytes32 subscriber` : Hash of the subscriber identity whose creator fee to claim.
 - Returns:
-  - `uint256` : Amount of creator fee claimed.
+  - `uint256 claimedAmount` : Amount of creator fee claimed.
 
 
 ---
@@ -509,7 +526,7 @@ All external functions for the registry and asset contracts, for use with JSON-R
 - Parameters:
   - `bytes32[] subscribers` : Array of subscriber identity hashes to claim for.
 - Returns:
-  - `uint256` : Total amount of creator fee claimed across all subscribers.
+  - `uint256 totalClaimedAmount` : Total amount of creator fee claimed across all subscribers.
 
 
 ---
@@ -520,7 +537,9 @@ All external functions for the registry and asset contracts, for use with JSON-R
 - Parameters:
   - `bytes32 subscriber` : Hash of the subscriber identity whose registry fee to claim.
 - Returns:
-  - `uint256` : Amount of registry fee claimed.
+  - `uint256 claimedAmount` : Amount of registry fee claimed.
+  - `uint256 claimedAtTimestamp` : Timestamp used as the upper claim bound for this call.
+  - `uint256 claimedAtNonce` : Subscription nonce reached while computing the claim.
 
 
 ---
@@ -531,7 +550,7 @@ All external functions for the registry and asset contracts, for use with JSON-R
 - Parameters:
   - `bytes32[] subscribers` : Array of subscriber identity hashes to claim for.
 - Returns:
-  - `uint256` : Total amount of registry fee claimed across all subscribers.
+  - `uint256 totalClaimedAmount` : Total amount of registry fee claimed across all subscribers.
 
 
 ---
@@ -584,11 +603,14 @@ All events emitted by the registry and asset contracts. Use for indexing, loggin
 
 ---
 
-**RegistryFeeClaimed** : Emitted when the registry fee for a single subscriber is claimed via the single-subscriber overload.
+**RegistryFeeClaimed** : Emitted when registry fee for a single subscriber claim cursor is materialized.
 - Contract: `AssetRegistry`
 - Parameters:
+  - `bytes32 indexed assetId` : Asset identifier for the claim.
   - `bytes32 indexed subscriber` : Subscriber whose registry fee was claimed.
   - `uint256 amount` : Amount of registry fee claimed.
+  - `uint256 claimedAtTimestamp` : Timestamp used as the upper claim bound.
+  - `uint256 claimedAtNonce` : Subscription nonce reached while computing the claim.
 
 
 ---
@@ -648,6 +670,8 @@ All events emitted by the registry and asset contracts. Use for indexing, loggin
 - Parameters:
   - `bytes32 indexed subscriber` : Subscriber whose creator fee was claimed.
   - `uint256 amount` : Amount of creator fee claimed.
+  - `uint256 indexed claimedAtTimestamp` : Timestamp used as the upper claim bound.
+  - `uint256 indexed claimedAtNonce` : Subscription nonce reached while computing the claim.
 
 
 ---

--- a/src/Asset.sol
+++ b/src/Asset.sol
@@ -80,7 +80,9 @@ contract Asset is Ownable, ReentrancyGuard, IAsset {
     );
 
     event SubscriptionExtended(bytes32 indexed subscriber, uint256 indexed endTime);
-    event CreatorFeeClaimed(bytes32 indexed subscriber, uint256 amount, uint256 indexed claimedAtTimestamp, uint256 indexed claimedAtNonce);
+    event CreatorFeeClaimed(
+        bytes32 indexed subscriber, uint256 amount, uint256 indexed claimedAtTimestamp, uint256 indexed claimedAtNonce
+    );
     event CreatorFeeClaimedBatch(bytes32[] indexed subscribers, uint256 totalAmount);
     event SubscriptionPriceUpdated(uint256 newSubscriptionPrice);
     event SubscriptionRevoked(bytes32 indexed subscriber, uint256 indexed nonce, uint256 indexed endTime);
@@ -383,7 +385,12 @@ contract Asset is Ownable, ReentrancyGuard, IAsset {
         return totalClaimedAmount;
     }
 
-    function claimRegistryFee(bytes32 subscriber) external onlyRegistry nonReentrant returns (uint256 claimedAmount, uint256 claimedAtTimestamp, uint256 claimedAtNonce) {
+    function claimRegistryFee(bytes32 subscriber)
+        external
+        onlyRegistry
+        nonReentrant
+        returns (uint256 claimedAmount, uint256 claimedAtTimestamp, uint256 claimedAtNonce)
+    {
         claimedAtTimestamp = block.timestamp;
 
         (claimedAmount, claimedAtNonce) = _claimable(

--- a/src/Asset.sol
+++ b/src/Asset.sol
@@ -80,7 +80,7 @@ contract Asset is Ownable, ReentrancyGuard, IAsset {
     );
 
     event SubscriptionExtended(bytes32 indexed subscriber, uint256 indexed endTime);
-    event CreatorFeeClaimed(bytes32 indexed subscriber, uint256 amount);
+    event CreatorFeeClaimed(bytes32 indexed subscriber, uint256 amount, uint256 indexed claimedAtTimestamp, uint256 indexed claimedAtNonce);
     event CreatorFeeClaimedBatch(bytes32[] indexed subscribers, uint256 totalAmount);
     event SubscriptionPriceUpdated(uint256 newSubscriptionPrice);
     event SubscriptionRevoked(bytes32 indexed subscriber, uint256 indexed nonce, uint256 indexed endTime);
@@ -313,7 +313,9 @@ contract Asset is Ownable, ReentrancyGuard, IAsset {
     function claimCreatorFee(bytes32 subscriber) external onlyOwner nonReentrant returns (uint256 creatorFee) {
         uint256 timestamp = block.timestamp;
 
-        (creatorFee, creatorClaimedAtNonces[subscriber]) = _claimable(
+        uint256 claimedAtNonce = creatorClaimedAtNonces[subscriber];
+
+        (creatorFee, claimedAtNonce) = _claimable(
             subscriber,
             creatorClaimedAtTimestamps[subscriber],
             creatorClaimedAtNonces[subscriber],
@@ -326,9 +328,10 @@ contract Asset is Ownable, ReentrancyGuard, IAsset {
             SafeERC20.safeTransfer(TOKEN_CONTRACT, owner(), creatorFee);
         }
 
-        creatorClaimedAtTimestamps[subscriber] = block.timestamp;
+        creatorClaimedAtTimestamps[subscriber] = timestamp;
+        creatorClaimedAtNonces[subscriber] = claimedAtNonce;
 
-        emit CreatorFeeClaimed(subscriber, creatorFee);
+        emit CreatorFeeClaimed(subscriber, creatorFee, timestamp, claimedAtNonce);
 
         return creatorFee;
     }
@@ -337,7 +340,7 @@ contract Asset is Ownable, ReentrancyGuard, IAsset {
         external
         onlyOwner
         nonReentrant
-        returns (uint256 claimed)
+        returns (uint256 totalClaimedAmount)
     {
         uint256 timestamp = block.timestamp;
 
@@ -348,7 +351,7 @@ contract Asset is Ownable, ReentrancyGuard, IAsset {
                 continue;
             }
 
-            (uint256 _creatorFee, uint256 _creatorClaimedAtNonce) = _claimable(
+            (uint256 claimedAmount, uint256 claimedAtNonce) = _claimable(
                 subscriber,
                 creatorClaimedAtTimestamps[subscriber],
                 creatorClaimedAtNonces[subscriber],
@@ -358,54 +361,55 @@ contract Asset is Ownable, ReentrancyGuard, IAsset {
             );
 
             // If the creator fee is 0, continue to the next subscriber
-            if (_creatorFee == 0) {
+            if (claimedAmount == 0) {
                 continue;
             }
 
             creatorClaimedAtTimestamps[subscriber] = timestamp;
 
-            creatorClaimedAtNonces[subscriber] = _creatorClaimedAtNonce;
+            creatorClaimedAtNonces[subscriber] = claimedAtNonce;
 
-            emit CreatorFeeClaimed(subscriber, _creatorFee);
+            emit CreatorFeeClaimed(subscriber, claimedAmount, timestamp, claimedAtNonce);
 
-            claimed += _creatorFee;
+            totalClaimedAmount += claimedAmount;
         }
 
-        if (claimed != 0) {
-            SafeERC20.safeTransfer(TOKEN_CONTRACT, owner(), claimed);
+        if (totalClaimedAmount != 0) {
+            SafeERC20.safeTransfer(TOKEN_CONTRACT, owner(), totalClaimedAmount);
         }
 
-        emit CreatorFeeClaimedBatch(_subscribers, claimed);
+        emit CreatorFeeClaimedBatch(_subscribers, totalClaimedAmount);
 
-        return claimed;
+        return totalClaimedAmount;
     }
 
-    function claimRegistryFee(bytes32 subscriber) external onlyRegistry nonReentrant returns (uint256 registryFee) {
-        uint256 timestamp = block.timestamp;
+    function claimRegistryFee(bytes32 subscriber) external onlyRegistry nonReentrant returns (uint256 claimedAmount, uint256 claimedAtTimestamp, uint256 claimedAtNonce) {
+        claimedAtTimestamp = block.timestamp;
 
-        (registryFee, registryClaimedAtNonces[subscriber]) = _claimable(
+        (claimedAmount, claimedAtNonce) = _claimable(
             subscriber,
             registryClaimedAtTimestamps[subscriber],
             registryClaimedAtNonces[subscriber],
             false,
             true,
-            timestamp
+            claimedAtTimestamp
         );
 
-        if (registryFee != 0) {
-            SafeERC20.safeTransfer(TOKEN_CONTRACT, ASSET_REGISTRY.getOwner(), registryFee);
+        if (claimedAmount != 0) {
+            SafeERC20.safeTransfer(TOKEN_CONTRACT, ASSET_REGISTRY.getOwner(), claimedAmount);
         }
 
-        registryClaimedAtTimestamps[subscriber] = block.timestamp;
+        registryClaimedAtTimestamps[subscriber] = claimedAtTimestamp;
+        registryClaimedAtNonces[subscriber] = claimedAtNonce;
 
-        return registryFee;
+        return (claimedAmount, claimedAtTimestamp, claimedAtNonce);
     }
 
     function claimRegistryFee(bytes32[] calldata _subscribers)
         external
         onlyRegistry
         nonReentrant
-        returns (uint256 claimed)
+        returns (uint256 totalClaimedAmount)
     {
         uint256 timestamp = block.timestamp;
 
@@ -416,7 +420,7 @@ contract Asset is Ownable, ReentrancyGuard, IAsset {
                 continue;
             }
 
-            (uint256 _registryFee, uint256 _registryClaimedAtNonce) = _claimable(
+            (uint256 claimedAmount, uint256 claimedAtNonce) = _claimable(
                 subscriber,
                 registryClaimedAtTimestamps[subscriber],
                 registryClaimedAtNonces[subscriber],
@@ -426,22 +430,24 @@ contract Asset is Ownable, ReentrancyGuard, IAsset {
             );
 
             // If the registry fee is 0, continue to the next subscriber
-            if (_registryFee == 0) {
+            if (claimedAmount == 0) {
                 continue;
             }
 
             registryClaimedAtTimestamps[subscriber] = timestamp;
 
-            registryClaimedAtNonces[subscriber] = _registryClaimedAtNonce;
+            registryClaimedAtNonces[subscriber] = claimedAtNonce;
 
-            claimed += _registryFee;
+            totalClaimedAmount += claimedAmount;
+
+            ASSET_REGISTRY.emitRegistryFeeClaimedEvent(ASSET_ID, subscriber, claimedAmount, timestamp, claimedAtNonce);
         }
 
-        if (claimed != 0) {
-            SafeERC20.safeTransfer(TOKEN_CONTRACT, ASSET_REGISTRY.getOwner(), claimed);
+        if (totalClaimedAmount != 0) {
+            SafeERC20.safeTransfer(TOKEN_CONTRACT, ASSET_REGISTRY.getOwner(), totalClaimedAmount);
         }
 
-        return claimed;
+        return totalClaimedAmount;
     }
 
     function _removeSubscription(bytes32 subscriber) internal {

--- a/src/AssetRegistry.sol
+++ b/src/AssetRegistry.sol
@@ -27,7 +27,13 @@ contract AssetRegistry is Ownable, IAssetRegistry {
         address indexed owner
     );
     event RegistryFeeShareUpdated(uint256 newRegistryFeeShare);
-    event RegistryFeeClaimed(bytes32 indexed assetId, bytes32 indexed subscriber, uint256 amount, uint256 claimedAtTimestamp, uint256 claimedAtNonce);
+    event RegistryFeeClaimed(
+        bytes32 indexed assetId,
+        bytes32 indexed subscriber,
+        uint256 amount,
+        uint256 claimedAtTimestamp,
+        uint256 claimedAtNonce
+    );
     event RegistryFeeClaimedBatch(bytes32 indexed assetId, bytes32[] indexed subscribers, uint256 totalAmount);
 
     /// @notice Initializes the registry with fee shares. Caller becomes owner.
@@ -145,7 +151,8 @@ contract AssetRegistry is Ownable, IAssetRegistry {
     function claimRegistryFee(bytes32 _assetId, bytes32 _subscriber) external onlyOwner returns (uint256) {
         address asset = getAsset(_assetId);
 
-        (uint256 claimedAmount, uint256 claimedAtTimestamp, uint256 claimedAtNonce) = IAsset(asset).claimRegistryFee(_subscriber);
+        (uint256 claimedAmount, uint256 claimedAtTimestamp, uint256 claimedAtNonce) =
+            IAsset(asset).claimRegistryFee(_subscriber);
 
         emit RegistryFeeClaimed(_assetId, _subscriber, claimedAmount, claimedAtTimestamp, claimedAtNonce);
 
@@ -169,14 +176,12 @@ contract AssetRegistry is Ownable, IAssetRegistry {
         uint256 claimedAmount,
         uint256 claimedAtTimestamp,
         uint256 claimedAtNonce
-    ) external
-    {
-        if (msg.sender != getAsset(_assetId))
-        {
+    ) external {
+        if (msg.sender != getAsset(_assetId)) {
             revert OnlyAssetUnauthorizedAccount();
         }
 
-        emit RegistryFeeClaimed(_assetId, _subscriber, claimedAmount, claimedAtTimestamp, claimedAtNonce); 
+        emit RegistryFeeClaimed(_assetId, _subscriber, claimedAmount, claimedAtTimestamp, claimedAtNonce);
     }
 
     function getOwner() external view returns (address) {

--- a/src/AssetRegistry.sol
+++ b/src/AssetRegistry.sol
@@ -16,6 +16,7 @@ contract AssetRegistry is Ownable, IAssetRegistry {
 
     error AssetAlreadyExists();
     error AssetNotFound();
+    error OnlyAssetUnauthorizedAccount();
     error RegistryFeeShareOutOfBounds();
 
     event AssetCreated(
@@ -26,7 +27,7 @@ contract AssetRegistry is Ownable, IAssetRegistry {
         address indexed owner
     );
     event RegistryFeeShareUpdated(uint256 newRegistryFeeShare);
-    event RegistryFeeClaimed(bytes32 indexed subscriber, uint256 amount);
+    event RegistryFeeClaimed(bytes32 indexed assetId, bytes32 indexed subscriber, uint256 amount, uint256 claimedAtTimestamp, uint256 claimedAtNonce);
     event RegistryFeeClaimedBatch(bytes32 indexed assetId, bytes32[] indexed subscribers, uint256 totalAmount);
 
     /// @notice Initializes the registry with fee shares. Caller becomes owner.
@@ -141,25 +142,41 @@ contract AssetRegistry is Ownable, IAssetRegistry {
         return (creatorFee, registryFee);
     }
 
-    function claimRegistryFee(bytes32 _assetId, bytes32 _subscriber) external onlyOwner returns (uint256 registryFee) {
+    function claimRegistryFee(bytes32 _assetId, bytes32 _subscriber) external onlyOwner returns (uint256) {
         address asset = getAsset(_assetId);
 
-        registryFee = IAsset(asset).claimRegistryFee(_subscriber);
+        (uint256 claimedAmount, uint256 claimedAtTimestamp, uint256 claimedAtNonce) = IAsset(asset).claimRegistryFee(_subscriber);
 
-        emit RegistryFeeClaimed(_subscriber, registryFee);
+        emit RegistryFeeClaimed(_assetId, _subscriber, claimedAmount, claimedAtTimestamp, claimedAtNonce);
 
-        return registryFee;
+        return claimedAmount;
     }
 
     function claimRegistryFee(bytes32 _assetId, bytes32[] calldata _subscribers)
         external
         onlyOwner
-        returns (uint256 claimed)
+        returns (uint256 totalClaimedAmount)
     {
         address asset = getAsset(_assetId);
-        claimed = IAsset(asset).claimRegistryFee(_subscribers);
-        emit RegistryFeeClaimedBatch(_assetId, _subscribers, claimed);
-        return claimed;
+        totalClaimedAmount = IAsset(asset).claimRegistryFee(_subscribers);
+        emit RegistryFeeClaimedBatch(_assetId, _subscribers, totalClaimedAmount);
+        return totalClaimedAmount;
+    }
+
+    function emitRegistryFeeClaimedEvent(
+        bytes32 _assetId,
+        bytes32 _subscriber,
+        uint256 claimedAmount,
+        uint256 claimedAtTimestamp,
+        uint256 claimedAtNonce
+    ) external
+    {
+        if (msg.sender != getAsset(_assetId))
+        {
+            revert OnlyAssetUnauthorizedAccount();
+        }
+
+        emit RegistryFeeClaimed(_assetId, _subscriber, claimedAmount, claimedAtTimestamp, claimedAtNonce); 
     }
 
     function getOwner() external view returns (address) {

--- a/src/IAsset.sol
+++ b/src/IAsset.sol
@@ -81,7 +81,9 @@ interface IAsset {
     /// @return claimedAmount The amount of registry fee claimed.
     /// @return claimedAtTimestamp The timestamp used as the upper claim bound for this call.
     /// @return claimedAtNonce The subscription nonce reached while computing the claim.
-    function claimRegistryFee(bytes32 subscriber) external returns (uint256 claimedAmount, uint256 claimedAtTimestamp, uint256 claimedAtNonce);
+    function claimRegistryFee(bytes32 subscriber)
+        external
+        returns (uint256 claimedAmount, uint256 claimedAtTimestamp, uint256 claimedAtNonce);
 
     /// @notice Claims the registry fee for multiple subscribers. Callable only by the registry contract.
     /// @param subscribers Array of subscriber hashes whose registry fee to claim.

--- a/src/IAsset.sol
+++ b/src/IAsset.sol
@@ -62,24 +62,31 @@ interface IAsset {
     ) external returns (uint256);
 
     /// @notice Claims the creator fee for a subscriber. Callable only by the asset owner.
+    ///         Updates and emits claim cursor metadata (`claimedAtTimestamp`, `claimedAtNonce`) in
+    ///         `CreatorFeeClaimed` to support deterministic indexer continuation.
     /// @param subscriber Subscriber hash whose creator fee to claim.
-    /// @return The amount of creator fee claimed.
-    function claimCreatorFee(bytes32 subscriber) external returns (uint256);
+    /// @return claimedAmount The amount of creator fee claimed.
+    function claimCreatorFee(bytes32 subscriber) external returns (uint256 claimedAmount);
 
     /// @notice Claims the creator fee for multiple subscribers. Callable only by the asset owner.
+    ///         Emits `CreatorFeeClaimed` per subscriber with per-subscriber claim cursor metadata,
+    ///         then emits `CreatorFeeClaimedBatch` once with the aggregate amount.
     /// @param subscribers Array of subscriber hashes whose creator fee to claim.
-    /// @return The amount of creator fee claimed.
-    function claimCreatorFee(bytes32[] calldata subscribers) external returns (uint256);
+    /// @return totalClaimedAmount The total amount of creator fee claimed across all subscribers.
+    function claimCreatorFee(bytes32[] calldata subscribers) external returns (uint256 totalClaimedAmount);
 
-    /// @notice Claims the registry fee for a subscriber. Callable only by the Registry owner.
+    /// @notice Claims the registry fee for a subscriber. Callable only by the registry contract.
+    ///         Returns claim cursor metadata so callers can emit or persist synchronized claim progress.
     /// @param subscriber Subscriber hash whose registry fee to claim.
-    /// @return The amount of registry fee claimed.
-    function claimRegistryFee(bytes32 subscriber) external returns (uint256);
+    /// @return claimedAmount The amount of registry fee claimed.
+    /// @return claimedAtTimestamp The timestamp used as the upper claim bound for this call.
+    /// @return claimedAtNonce The subscription nonce reached while computing the claim.
+    function claimRegistryFee(bytes32 subscriber) external returns (uint256 claimedAmount, uint256 claimedAtTimestamp, uint256 claimedAtNonce);
 
-    /// @notice Claims the registry fee for multiple subscribers. Callable only by the Registry owner.
+    /// @notice Claims the registry fee for multiple subscribers. Callable only by the registry contract.
     /// @param subscribers Array of subscriber hashes whose registry fee to claim.
-    /// @return The amount of registry fee claimed.
-    function claimRegistryFee(bytes32[] calldata subscribers) external returns (uint256);
+    /// @return totalClaimedAmount The total amount of registry fee claimed across all subscribers.
+    function claimRegistryFee(bytes32[] calldata subscribers) external returns (uint256 totalClaimedAmount);
 
     /// @notice Revokes a subscriber's subscription. Callable only by the asset owner.
     /// @param subscriber Subscriber hash whose subscription to revoke.

--- a/src/IAssetRegistry.sol
+++ b/src/IAssetRegistry.sol
@@ -103,17 +103,37 @@ interface IAssetRegistry {
     /// @return registryFee The registry fee.
     function getFees(uint256 _value) external view returns (uint256 creatorFee, uint256 registryFee);
 
-    /// @notice Claims the registry fee for a subscriber hash. Callable only by the Registry owner.
+    /// @notice Claims the registry fee for a subscriber hash. Callable only by the registry owner.
+    ///         Internally uses the asset-returned claim cursor metadata when emitting
+    ///         `RegistryFeeClaimed(assetId, subscriber, amount, claimedAtTimestamp, claimedAtNonce)`.
     /// @param _assetId Asset identifier.
     /// @param _subscriber Subscriber hash.
-    /// @return The amount of registry fee claimed.
+    /// @return claimedAmount The amount of registry fee claimed.
     function claimRegistryFee(bytes32 _assetId, bytes32 _subscriber) external returns (uint256);
 
-    /// @notice Claims the registry fee for multiple subscriber hashes. Callable only by the Registry owner.
+    /// @notice Claims the registry fee for multiple subscriber hashes. Callable only by the registry owner.
+    ///         Emits `RegistryFeeClaimedBatch` once with the aggregate amount.
     /// @param _assetId Asset identifier.
     /// @param _subscribers Array of subscriber hashes.
-    /// @return The amount of registry fee claimed.
-    function claimRegistryFee(bytes32 _assetId, bytes32[] calldata _subscribers) external returns (uint256);
+    /// @return totalClaimedAmount The total amount of registry fee claimed across all subscribers.
+    function claimRegistryFee(bytes32 _assetId, bytes32[] calldata _subscribers)
+        external
+        returns (uint256 totalClaimedAmount);
+
+    /// @notice Emits a `RegistryFeeClaimed` event for a single subscriber claim cursor update.
+    ///         Callable only by the asset identified by `_assetId`.
+    /// @param _assetId Asset identifier.
+    /// @param _subscriber Subscriber hash.
+    /// @param claimedAmount Registry fee amount claimed.
+    /// @param claimedAtTimestamp Timestamp used as upper claim bound.
+    /// @param claimedAtNonce Subscription nonce reached while computing the claim.
+    function emitRegistryFeeClaimedEvent(
+        bytes32 _assetId,
+        bytes32 _subscriber,
+        uint256 claimedAmount,
+        uint256 claimedAtTimestamp,
+        uint256 claimedAtNonce
+    ) external;
 
     /// @notice Returns the owner of the registry (e.g. for receiving registry fees).
     /// @return The registry owner address.

--- a/test/Asset.t.sol
+++ b/test/Asset.t.sol
@@ -159,7 +159,7 @@ contract AssetTest is BaseTest {
         vm.startPrank(assetOwner);
         uint256 creatorFee = assetRegistry.getCreatorFee(value);
         vm.expectEmit(true, true, true, true);
-        emit Asset.CreatorFeeClaimed(_subscriber, creatorFee);
+        emit Asset.CreatorFeeClaimed(_subscriber, creatorFee, block.timestamp, 0);
         uint256 claimedCreatorFee = asset.claimCreatorFee(_subscriber);
         vm.stopPrank();
 
@@ -179,7 +179,7 @@ contract AssetTest is BaseTest {
 
         uint256 creatorFee = assetRegistry.getCreatorFee(value);
         vm.expectEmit(true, true, true, true);
-        emit Asset.CreatorFeeClaimed(_subscriber, creatorFee);
+        emit Asset.CreatorFeeClaimed(_subscriber, creatorFee, block.timestamp, 0);
 
         uint256 claimedCreatorFee = asset.claimCreatorFee(_subscriber);
 
@@ -210,7 +210,7 @@ contract AssetTest is BaseTest {
 
         vm.startPrank(assetOwner);
         vm.expectEmit(true, true, true, true);
-        emit Asset.CreatorFeeClaimed(_subscriber, creatorFee);
+        emit Asset.CreatorFeeClaimed(_subscriber, creatorFee, block.timestamp, 1);
         uint256 claimedCreatorFee = asset.claimCreatorFee(_subscriber);
         vm.stopPrank();
 
@@ -228,7 +228,7 @@ contract AssetTest is BaseTest {
         vm.startPrank(assetOwner);
         uint256 creatorFee = assetRegistry.getCreatorFee(value) / 2;
         vm.expectEmit(true, true, true, true);
-        emit Asset.CreatorFeeClaimed(_subscriber, creatorFee);
+        emit Asset.CreatorFeeClaimed(_subscriber, creatorFee, block.timestamp, 0);
         uint256 claimedCreatorFee = asset.claimCreatorFee(_subscriber);
         vm.stopPrank();
 
@@ -294,7 +294,7 @@ contract AssetTest is BaseTest {
         vm.startPrank(assetOwner);
         uint256 creatorFee = assetRegistry.getCreatorFee(value);
         vm.expectEmit(true, true, true, true);
-        emit Asset.CreatorFeeClaimed(_subscriber, creatorFee);
+        emit Asset.CreatorFeeClaimed(_subscriber, creatorFee, block.timestamp, 0);
         uint256 claimedCreatorFee = asset.claimCreatorFee(_subscriber);
         vm.stopPrank();
 
@@ -719,7 +719,7 @@ contract AssetTest is BaseTest {
         uint256 claimedCreatorFee = asset.claimCreatorFee(_subscriber);
 
         vm.prank(address(assetRegistry));
-        uint256 claimedRegistryFee = asset.claimRegistryFee(_subscriber);
+        (uint256 claimedRegistryFee,,) = asset.claimRegistryFee(_subscriber);
 
         assertEq(claimedCreatorFee, creatorFee);
         assertEq(claimedRegistryFee, registryFee);
@@ -764,7 +764,7 @@ contract AssetTest is BaseTest {
         uint256 registryOwnerBalanceBefore = testToken.balanceOf(registryOwner);
 
         vm.prank(address(assetRegistry));
-        uint256 claimed = asset.claimRegistryFee(_subscriber);
+        (uint256 claimed,,) = asset.claimRegistryFee(_subscriber);
 
         assertEq(claimed, 0);
         assertEq(testToken.balanceOf(registryOwner), registryOwnerBalanceBefore);
@@ -786,7 +786,7 @@ contract AssetTest is BaseTest {
         uint256 registryOwnerBalanceBefore = testToken.balanceOf(registryOwner);
 
         vm.prank(address(assetRegistry));
-        uint256 claimed = asset.claimRegistryFee(neverSubscribed);
+        (uint256 claimed,,) = asset.claimRegistryFee(neverSubscribed);
 
         assertEq(claimed, 0);
         assertEq(testToken.balanceOf(registryOwner), registryOwnerBalanceBefore);
@@ -899,9 +899,9 @@ contract AssetTest is BaseTest {
 
         vm.startPrank(assetOwner);
         vm.expectEmit(true, true, true, true);
-        emit Asset.CreatorFeeClaimed(_subscriber, creatorFeePerSubscriber);
+        emit Asset.CreatorFeeClaimed(_subscriber, creatorFeePerSubscriber, block.timestamp, 0);
         vm.expectEmit(true, true, true, true);
-        emit Asset.CreatorFeeClaimed(subscriber2, creatorFeePerSubscriber);
+        emit Asset.CreatorFeeClaimed(subscriber2, creatorFeePerSubscriber, block.timestamp, 0);
         vm.expectEmit(true, true, true, true);
         emit Asset.CreatorFeeClaimedBatch(subs, creatorFeePerSubscriber * 2);
         uint256 claimed = asset.claimCreatorFee(subs);
@@ -1099,7 +1099,7 @@ contract AssetTest is BaseTest {
         uint256 expectedFee = assetRegistry.getRegistryFee(value);
 
         vm.prank(address(assetRegistry));
-        uint256 claimed = asset.claimRegistryFee(_subscriber);
+        (uint256 claimed,,) = asset.claimRegistryFee(_subscriber);
         assertEq(claimed, expectedFee);
     }
 }

--- a/test/AssetRegistry.t.sol
+++ b/test/AssetRegistry.t.sol
@@ -224,7 +224,7 @@ contract AssetRegistryTest is BaseTest {
 
         vm.prank(registryOwner);
         vm.expectEmit(true, true, true, true);
-        emit AssetRegistry.RegistryFeeClaimed(_subscriber, registryFee);
+        emit AssetRegistry.RegistryFeeClaimed(ASSET_ID, _subscriber, registryFee, block.timestamp, 0);
         assetRegistry.claimRegistryFee(ASSET_ID, _subscriber);
 
         assertEq(testToken.balanceOf(registryOwner), tokenBalance + registryFee);
@@ -243,7 +243,7 @@ contract AssetRegistryTest is BaseTest {
 
         vm.prank(registryOwner);
         vm.expectEmit(true, true, true, true);
-        emit AssetRegistry.RegistryFeeClaimed(_subscriber, registryFee);
+        emit AssetRegistry.RegistryFeeClaimed(ASSET_ID, _subscriber, registryFee, block.timestamp, 0);
         assetRegistry.claimRegistryFee(ASSET_ID, _subscriber);
 
         assertEq(testToken.balanceOf(registryOwner), tokenBalance + registryFee);
@@ -309,7 +309,7 @@ contract AssetRegistryTest is BaseTest {
 
         vm.prank(registryOwner);
         vm.expectEmit(true, true, true, true);
-        emit AssetRegistry.RegistryFeeClaimed(_subscriber, registryFee);
+        emit AssetRegistry.RegistryFeeClaimed(ASSET_ID, _subscriber, registryFee, block.timestamp, 1);
         assetRegistry.claimRegistryFee(ASSET_ID, _subscriber);
 
         assertEq(testToken.balanceOf(registryOwner), tokenBalance + registryFee);
@@ -325,7 +325,7 @@ contract AssetRegistryTest is BaseTest {
 
         vm.prank(registryOwner);
         vm.expectEmit(true, true, true, true);
-        emit AssetRegistry.RegistryFeeClaimed(_subscriber, registryFee);
+        emit AssetRegistry.RegistryFeeClaimed(ASSET_ID, _subscriber, registryFee, block.timestamp, 0);
         assetRegistry.claimRegistryFee(ASSET_ID, _subscriber);
 
         assertEq(testToken.balanceOf(registryOwner), tokenBalance + registryFee);
@@ -343,7 +343,7 @@ contract AssetRegistryTest is BaseTest {
         uint256 registryFee = assetRegistry.getRegistryFee(value);
         vm.prank(registryOwner);
         vm.expectEmit(true, true, true, true);
-        emit AssetRegistry.RegistryFeeClaimed(_subscriber, registryFee);
+        emit AssetRegistry.RegistryFeeClaimed(ASSET_ID, _subscriber, registryFee, block.timestamp, 0);
         assetRegistry.claimRegistryFee(ASSET_ID, _subscriber);
 
         assertEq(testToken.balanceOf(registryOwner), tokenBalance + registryFee);


### PR DESCRIPTION
## Summary
- add claim cursor metadata (`claimedAtTimestamp`, `claimedAtNonce`) to creator and registry claimed event flows
- align `Asset`/`AssetRegistry` interfaces and implementations for new claim return semantics and event emission paths
- update Foundry tests and README RPC/event documentation to match new method and event signatures

## Test plan
- [x] `forge test`

Made with [Cursor](https://cursor.com)