### PR TITLE
Cancel subscription and fee claim scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Open Creator Rails is a minimal, verifiable on-chain primitive for managing acce
    export RPC_URL=http://127.0.0.1:8545
    ```
 
-   > **Note:** Scripts do **not** auto-source the env file themselves — you must source it before running individual scripts (`source .env` or `source .env.local`), or pass the env file path to `seed.sh` as the first argument (e.g. `./scripts/seed.sh .env.local`).
+   > **Note:** All scripts optionally accept an environment file (`.env` or `.env.local`) as their first argument (e.g. `./scripts/subscribe.sh .env.local ...`). If `.env.local` is passed, Anvil is automatically started before the script runs. Alternatively, source the env file manually in your shell before running any script: `source .env` or `source .env.local`.
 
 3. **Build**
 
@@ -76,18 +76,19 @@ Open Creator Rails is a minimal, verifiable on-chain primitive for managing acce
 Deploy an AssetRegistry with the specified registry fee share:
 
 ```bash
-./scripts/deployRegistry.sh <registry_fee_share> <registry_owner_private_key>
+./scripts/deployRegistry.sh [env_file] <registry_fee_share> <registry_owner_private_key>
 ```
 
 | Input | Description |
 |-------|--------------|
+| `env_file` | Path to an env file to source (e.g. `.env` or `.env.local`). If `.env.local` is passed, Anvil is auto-started. |
 | `registry_fee_share` | Percentage of subscription payments allocated to the registry. Must be 0–100. The creator receives the remainder (`100 - registry_fee_share`). |
 | `registry_owner_private_key` | Private key of the registry owner; used to deploy the contract and send transactions. |
 
 Example:
 
 ```bash
-./scripts/deployRegistry.sh 20 0x1b97...
+./scripts/deployRegistry.sh .env.local 20 0x1b97...
 ```
 
 Deployments are recorded in `deployments/registries_<chain_id>.json`, where `chain_id` is the chain ID of the network from `RPC_URL` (e.g. `registries_11155111.json` for Sepolia, `registries_84532.json` for Base Sepolia). The file is an array of registry objects with `address`, `registryFeeShare`, `owner`, and `assets`.
@@ -97,11 +98,12 @@ Deployments are recorded in `deployments/registries_<chain_id>.json`, where `cha
 Create an asset in a registry (registry owner only):
 
 ```bash
-./scripts/createAsset.sh <registry_index> <asset_id> <subscription_price> <subscription_duration> <token_address> <owner> <registry_owner_private_key>
+./scripts/createAsset.sh [env_file] <registry_index> <asset_id> <subscription_price> <subscription_duration> <token_address> <owner> <registry_owner_private_key>
 ```
 
 | Input | Description |
 |-------|--------------|
+| `env_file` | Path to an env file to source (e.g. `.env` or `.env.local`). If `.env.local` is passed, Anvil is auto-started. |
 | `registry_index` | Zero-based index of the registry in `deployments/registries_<chain_id>.json` (e.g. `0` for the first registry). |
 | `asset_id` | Human-readable identifier for the asset. The script hashes it with keccak256 to get the bytes32 used on-chain. |
 | `subscription_price` | Price for one subscription period, in the token’s smallest unit. Must be a non-zero multiple of 100 to ensure integer precision when splitting fees between the registry and creator (`fee × registryFeeShare / 100`). Total payment for `n` periods is `n * subscription_price` (see `getSubscriptionPrice`). |
@@ -113,7 +115,7 @@ Create an asset in a registry (registry owner only):
 Example:
 
 ```bash
-./scripts/createAsset.sh 0 "default_asset_id" 4 3600 0x1234... 0xabcd... 0x1b97...
+./scripts/createAsset.sh .env.local 0 "default_asset_id" 4 3600 0x1234... 0xabcd... 0x1b97...
 ```
 
 The token address must implement ERC-2612 / IERC20Permit, as subscription payments use gasless permit approvals.
@@ -125,11 +127,12 @@ New assets are appended to the `assets` array of the corresponding registry in `
 Subscribe to an asset using ERC-2612 permit (gasless approval). The payer signs the permit and pays with tokens; the subscription is associated with a **subscriber** identity (a `bytes32` hash). The subscriber hash is computed as `keccak256(abi.encode(subscriber_id, subscriber_address))`, so only that `subscriber_address` can cancel by signing an off-chain message and calling `cancelSubscription` in one step (no on-chain commit or timestamp binding). The payer and the subscriber can be the same or different (e.g. “pay for someone else”). The **payer** is the address entitled to refunds if the subscription is later cancelled or revoked (unearned time is refunded to the payer).
 
 ```bash
-./scripts/subscribe.sh <registry_index> <asset_id> <subscriber_id> <subscriber_address> <count> <payer_private_key>
+./scripts/subscribe.sh [env_file] <registry_index> <asset_id> <subscriber_id> <subscriber_address> <count> <payer_private_key>
 ```
 
 | Input | Description |
 |-------|--------------|
+| `env_file` | Path to an env file to source (e.g. `.env` or `.env.local`). If `.env.local` is passed, Anvil is auto-started. |
 | `registry_index` | Zero-based index of the registry in `deployments/registries_<chain_id>.json`. |
 | `asset_id` | Human-readable asset identifier (same string used when creating the asset). The script hashes it with keccak256 for the on-chain call. |
 | `subscriber_id` | Human-readable subscriber identity (e.g. user id, wallet-derived id). Combined with `subscriber_address` to derive the on-chain `bytes32` subscriber hash: `keccak256(abi.encode(subscriber_id, subscriber_address))`. |
@@ -140,7 +143,123 @@ Subscribe to an asset using ERC-2612 permit (gasless approval). The payer signs 
 Example:
 
 ```bash
-./scripts/subscribe.sh 0 "default_asset_id" "user_123" 0xabcd... 12 0x1b97...
+./scripts/subscribe.sh .env.local 0 "default_asset_id" "user_123" 0xabcd... 12 0x1b97...
+```
+
+### Cancel Subscription
+
+Cancel a subscription as the subscriber. Unearned whole subscription periods are refunded to the original payer; partial periods are non-refundable. The subscriber signs an EIP-191 message off-chain and the script submits `cancelSubscription` in a single transaction — no on-chain commit step is required. Reverts if the subscriber has been permanently revoked by the asset owner.
+
+```bash
+./scripts/cancelSubscription.sh [env_file] <registry_index> <asset_id> <subscriber_id> <subscriber_private_key>
+```
+
+| Input | Description |
+|-------|--------------|
+| `env_file` | Path to an env file to source (e.g. `.env` or `.env.local`). If `.env.local` is passed, Anvil is auto-started. |
+| `registry_index` | Zero-based index of the registry in `deployments/registries_<chain_id>.json`. |
+| `asset_id` | Human-readable asset identifier (same string used when creating the asset). |
+| `subscriber_id` | Human-readable subscriber identity string used when subscribing. Combined with `msg.sender` (the subscriber's address) to derive the on-chain subscriber hash. |
+| `subscriber_private_key` | Private key of the subscriber. Used both to sign the cancellation payload off-chain and to send the transaction on-chain (`msg.sender` must match the subscriber address). |
+
+Example:
+
+```bash
+./scripts/cancelSubscription.sh .env.local 0 "default_asset_id" "user_123" 0x1b97...
+```
+
+### Claim Creator Fee
+
+Claim the accrued creator fee for a single subscriber (asset owner only). Accrual covers all completed subscription periods since the last claim; any partial-period dust is also claimable once the subscription has fully ended. Logs the claimed amount formatted with the token's symbol and decimals.
+
+```bash
+./scripts/claimCreatorFee.sh [env_file] <registry_index> <asset_id> <subscriber> <asset_owner_private_key>
+```
+
+| Input | Description |
+|-------|--------------|
+| `env_file` | Path to an env file to source (e.g. `.env` or `.env.local`). If `.env.local` is passed, Anvil is auto-started. |
+| `registry_index` | Zero-based index of the registry in `deployments/registries_<chain_id>.json`. |
+| `asset_id` | Human-readable asset identifier (same string used when creating the asset). |
+| `subscriber` | Pre-computed `bytes32` subscriber hash: `keccak256(abi.encode(subscriber_id, subscriber_address))`. Compute it with: `$(cast keccak "$(cast abi-encode "f(string,address)" "$subscriber_id" "$subscriber_address")")`. |
+| `asset_owner_private_key` | Private key of the asset owner. Used to send the transaction. |
+
+Example:
+
+```bash
+SUBSCRIBER=$(cast keccak "$(cast abi-encode "f(string,address)" "user_123" 0xabcd...)")
+./scripts/claimCreatorFee.sh .env.local 0 "default_asset_id" $SUBSCRIBER 0x1b97...
+```
+
+### Claim Creator Fee (Batch)
+
+Claim accrued creator fees for multiple subscribers in a single transaction (asset owner only). Subscribers with no accrued fee are silently skipped. Logs the total claimed amount formatted with the token's symbol and decimals.
+
+```bash
+./scripts/claimCreatorFeeBatch.sh [env_file] <registry_index> <asset_id> <asset_owner_private_key> <subscriber_1> [<subscriber_2> ...]
+```
+
+| Input | Description |
+|-------|--------------|
+| `env_file` | Path to an env file to source (e.g. `.env` or `.env.local`). If `.env.local` is passed, Anvil is auto-started. |
+| `registry_index` | Zero-based index of the registry in `deployments/registries_<chain_id>.json`. |
+| `asset_id` | Human-readable asset identifier (same string used when creating the asset). |
+| `asset_owner_private_key` | Private key of the asset owner. Used to send the transaction. |
+| `subscriber_1`, `subscriber_2`, … | One or more pre-computed `bytes32` subscriber hashes: `keccak256(abi.encode(subscriber_id, subscriber_address))`. Each can be computed with: `$(cast keccak "$(cast abi-encode "f(string,address)" "$subscriber_id" "$subscriber_address")")`. |
+
+Example:
+
+```bash
+SUB_0=$(cast keccak "$(cast abi-encode "f(string,address)" "user_0" 0xaaaa...)")
+SUB_1=$(cast keccak "$(cast abi-encode "f(string,address)" "user_1" 0xbbbb...)")
+./scripts/claimCreatorFeeBatch.sh .env.local 0 "default_asset_id" 0x1b97... $SUB_0 $SUB_1
+```
+
+### Claim Registry Fee
+
+Claim the accrued registry fee for a single subscriber (registry owner only). Logs the claimed amount formatted with the token's symbol and decimals.
+
+```bash
+./scripts/claimRegistryFee.sh [env_file] <registry_index> <asset_id> <subscriber> <registry_owner_private_key>
+```
+
+| Input | Description |
+|-------|--------------|
+| `env_file` | Path to an env file to source (e.g. `.env` or `.env.local`). If `.env.local` is passed, Anvil is auto-started. |
+| `registry_index` | Zero-based index of the registry in `deployments/registries_<chain_id>.json`. |
+| `asset_id` | Human-readable asset identifier (same string used when creating the asset). |
+| `subscriber` | Pre-computed `bytes32` subscriber hash: `keccak256(abi.encode(subscriber_id, subscriber_address))`. Compute it with: `$(cast keccak "$(cast abi-encode "f(string,address)" "$subscriber_id" "$subscriber_address")")`. |
+| `registry_owner_private_key` | Private key of the registry owner. Used to send the transaction. |
+
+Example:
+
+```bash
+SUBSCRIBER=$(cast keccak "$(cast abi-encode "f(string,address)" "user_123" 0xabcd...)")
+./scripts/claimRegistryFee.sh .env.local 0 "default_asset_id" $SUBSCRIBER 0x1b97...
+```
+
+### Claim Registry Fee (Batch)
+
+Claim accrued registry fees for multiple subscribers in a single transaction (registry owner only). Subscribers with no accrued fee are silently skipped. Logs the total claimed amount formatted with the token's symbol and decimals.
+
+```bash
+./scripts/claimRegistryFeeBatch.sh [env_file] <registry_index> <asset_id> <registry_owner_private_key> <subscriber_1> [<subscriber_2> ...]
+```
+
+| Input | Description |
+|-------|--------------|
+| `env_file` | Path to an env file to source (e.g. `.env` or `.env.local`). If `.env.local` is passed, Anvil is auto-started. |
+| `registry_index` | Zero-based index of the registry in `deployments/registries_<chain_id>.json`. |
+| `asset_id` | Human-readable asset identifier (same string used when creating the asset). |
+| `registry_owner_private_key` | Private key of the registry owner. Used to send the transaction. |
+| `subscriber_1`, `subscriber_2`, … | One or more pre-computed `bytes32` subscriber hashes: `keccak256(abi.encode(subscriber_id, subscriber_address))`. Each can be computed with: `$(cast keccak "$(cast abi-encode "f(string,address)" "$subscriber_id" "$subscriber_address")")`. |
+
+Example:
+
+```bash
+SUB_0=$(cast keccak "$(cast abi-encode "f(string,address)" "user_0" 0xaaaa...)")
+SUB_1=$(cast keccak "$(cast abi-encode "f(string,address)" "user_1" 0xbbbb...)")
+./scripts/claimRegistryFeeBatch.sh .env.local 0 "default_asset_id" 0x1b97... $SUB_0 $SUB_1
 ```
 
 ### Set Subscription Price
@@ -148,11 +267,12 @@ Example:
 Update the subscription price for an asset (asset owner only):
 
 ```bash
-./scripts/setSubscriptionPrice.sh <registry_index> <asset_id> <new_subscription_price> <asset_owner_private_key>
+./scripts/setSubscriptionPrice.sh [env_file] <registry_index> <asset_id> <new_subscription_price> <asset_owner_private_key>
 ```
 
 | Input | Description |
 |-------|--------------|
+| `env_file` | Path to an env file to source (e.g. `.env` or `.env.local`). If `.env.local` is passed, Anvil is auto-started. |
 | `registry_index` | Zero-based index of the registry in `deployments/registries_<chain_id>.json`. |
 | `asset_id` | Human-readable asset identifier (same string used when creating the asset). |
 | `new_subscription_price` | New price per subscription period in the token's smallest unit. Must be a non-zero multiple of 100; reverts with `InvalidSubscriptionPrice` otherwise. |
@@ -161,7 +281,7 @@ Update the subscription price for an asset (asset owner only):
 Example:
 
 ```bash
-./scripts/setSubscriptionPrice.sh 0 "default_asset_id" 200 0x1b97...
+./scripts/setSubscriptionPrice.sh .env.local 0 "default_asset_id" 200 0x1b97...
 ```
 
 The script updates the `subscriptionPrice` for the asset in `deployments/registries_<chain_id>.json`.
@@ -171,11 +291,12 @@ The script updates the `subscriptionPrice` for the asset in `deployments/registr
 Transfer ownership of an asset to a new address (asset owner only). The asset owner is the address that can claim the creator fee share of subscription payments.
 
 ```bash
-./scripts/transferAssetOwnership.sh <registry_index> <asset_id> <asset_owner_private_key> <new_owner>
+./scripts/transferAssetOwnership.sh [env_file] <registry_index> <asset_id> <asset_owner_private_key> <new_owner>
 ```
 
 | Input | Description |
 |-------|--------------|
+| `env_file` | Path to an env file to source (e.g. `.env` or `.env.local`). If `.env.local` is passed, Anvil is auto-started. |
 | `registry_index` | Zero-based index of the registry in `deployments/registries_<chain_id>.json`. |
 | `asset_id` | Human-readable asset identifier (same string used when creating the asset). |
 | `asset_owner_private_key` | Private key of the current asset owner. Used to send the transaction. |
@@ -184,7 +305,7 @@ Transfer ownership of an asset to a new address (asset owner only). The asset ow
 Example:
 
 ```bash
-./scripts/transferAssetOwnership.sh 0 "default_asset_id" 0x1b97... 0xabcd...
+./scripts/transferAssetOwnership.sh .env.local 0 "default_asset_id" 0x1b97... 0xabcd...
 ```
 
 The script updates the `owner` for the asset in `deployments/registries_<chain_id>.json`.
@@ -241,17 +362,18 @@ Use `seed.sh` to spin up a fully seeded local environment in one command. Pass t
 > **Deploy a test token** (records the address in `deployments/token_addresses.json` for the current chain):
 >
 > ```bash
-> ./scripts/deployTestToken.sh
+> ./scripts/deployTestToken.sh [env_file]
 > ```
 >
 > **Mint test tokens** to an address (uses the token in `deployments/token_addresses.json` for the current chain):
 >
 > ```bash
-> ./scripts/mintTestToken.sh <to> <amount>
+> ./scripts/mintTestToken.sh [env_file] <to> <amount>
 > ```
 >
 > | Input | Description |
 > |-------|--------------|
+> | `env_file` | Path to an env file to source (e.g. `.env` or `.env.local`). If `.env.local` is passed, Anvil is auto-started. |
 > | `to` | Recipient address. |
 > | `amount` | Amount to mint in the token's smallest unit. |
 

--- a/scripts/cancelSubscription.sh
+++ b/scripts/cancelSubscription.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+source ./scripts/utils.sh
+
+registry_index=$1
+asset_id=$(cast keccak "$2")
+subscriber_id=$3    
+subscriber_private_key=$4
+
+registry_address=$(get_address $registry_index)
+
+asset_address=$(cast call $registry_address "getAsset(bytes32)(address)" $asset_id --rpc-url $RPC_URL --from $(get_wallet_address 0))
+
+signed_cancel=$(forge script scripts/Utils.s.sol:UtilsScript --sig "signCancel(string,address,uint256)" "$subscriber_id" $asset_address $subscriber_private_key --rpc-url $RPC_URL --private-key $(get_private_key 0) --json)
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+    return $EXIT_CODE 2>/dev/null || exit $EXIT_CODE
+fi
+
+signature=$(echo $signed_cancel | jq -r '.returns.signature.value')
+subscriber=$(echo $signed_cancel | jq -r '.returns.subscriber.value')
+
+result=$(cast send $asset_address "cancelSubscription(string,bytes)" "$subscriber_id" $signature --rpc-url $RPC_URL --private-key $subscriber_private_key --json)
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+    return $EXIT_CODE 2>/dev/null || exit $EXIT_CODE
+fi
+
+transaction_hash=$(echo $result | jq -r '.transactionHash')
+
+subscription=$(cast call $asset_address "getSubscriptionExpiration(bytes32)(uint256)" $subscriber --rpc-url $RPC_URL --from $(get_wallet_address 0) --json)
+subscription_date=$(date -d @$(echo "$subscription" | jq -r '.[0]'))
+
+echo "Asset Registry: $registry_address
+Asset Address: $asset_address
+Asset ID: $2
+Subscriber ID: $subscriber_id
+Subscriber: $subscriber
+Subscription Expiration: $subscription_date
+Transaction Hash: $transaction_hash"

--- a/scripts/cancelSubscription.sh
+++ b/scripts/cancelSubscription.sh
@@ -2,6 +2,11 @@
 
 source ./scripts/utils.sh
 
+source_environment $1
+if [ $? -eq 0 ]; then
+    shift 1
+fi
+
 registry_index=$1
 asset_id=$(cast keccak "$2")
 subscriber_id=$3    

--- a/scripts/claimCreatorFee.sh
+++ b/scripts/claimCreatorFee.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+source ./scripts/utils.sh
+
+source_environment $1
+if [ $? -eq 0 ]; then
+    shift 1
+fi
+
+registry_index=$1
+asset_id=$(cast keccak "$2")
+subscriber=$3
+asset_owner_private_key=$4
+
+registry_address=$(get_address $registry_index)
+
+asset_address=$(cast call $registry_address "getAsset(bytes32)(address)" $asset_id --rpc-url $RPC_URL --from $(get_wallet_address 0))
+
+token_address=$(cast call $asset_address "getTokenAddress()(address)" --rpc-url $RPC_URL --from $(get_wallet_address 0))
+token_symbol=$(cast call $token_address "symbol()(string)" --rpc-url $RPC_URL | tr -d '"')
+token_decimals=$(cast call $token_address "decimals()(uint8)" --rpc-url $RPC_URL)
+
+result=$(cast send $asset_address "claimCreatorFee(bytes32)" $subscriber --rpc-url $RPC_URL --private-key $asset_owner_private_key --json)
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+    return $EXIT_CODE 2>/dev/null || exit $EXIT_CODE
+fi
+
+transaction_hash=$(echo $result | jq -r '.transactionHash')
+
+# CreatorFeeClaimed(bytes32 indexed subscriber, uint256 amount, uint256 indexed claimedAtTimestamp, uint256 indexed claimedAtNonce)
+# amount is the only non-indexed field — it is the entire data payload
+event_sig=$(cast keccak "CreatorFeeClaimed(bytes32,uint256,uint256,uint256)")
+log_data=$(echo $result | jq -r --arg sig "$event_sig" '.logs[] | select(.topics[0] == $sig) | .data')
+claimed_amount=$(cast --to-dec "$log_data")
+claimed_formatted=$(awk "BEGIN { printf \"%g\", $claimed_amount / (10 ^ $token_decimals) }")
+
+echo "Asset Address: $asset_address
+Asset ID: $2
+Subscriber: $subscriber
+Claimed: $claimed_formatted $token_symbol
+Transaction Hash: $transaction_hash"

--- a/scripts/claimCreatorFeeBatch.sh
+++ b/scripts/claimCreatorFeeBatch.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+source ./scripts/utils.sh
+
+source_environment $1
+if [ $? -eq 0 ]; then
+    shift 1
+fi
+
+registry_index=$1
+asset_id=$(cast keccak "$2")
+asset_owner_private_key=$3
+shift 3
+
+subscribers_array="["
+subscriber_list=""
+first=true
+while [ $# -ge 1 ]; do
+    hash=$1
+    shift 1
+    if [ "$first" = true ]; then
+        subscribers_array+="$hash"
+        first=false
+    else
+        subscribers_array+=",$hash"
+    fi
+    subscriber_list+="  $hash\n"
+done
+subscribers_array+="]"
+
+registry_address=$(get_address $registry_index)
+
+asset_address=$(cast call $registry_address "getAsset(bytes32)(address)" $asset_id --rpc-url $RPC_URL --from $(get_wallet_address 0))
+
+token_address=$(cast call $asset_address "getTokenAddress()(address)" --rpc-url $RPC_URL --from $(get_wallet_address 0))
+token_symbol=$(cast call $token_address "symbol()(string)" --rpc-url $RPC_URL | tr -d '"')
+token_decimals=$(cast call $token_address "decimals()(uint8)" --rpc-url $RPC_URL)
+
+result=$(cast send $asset_address "claimCreatorFee(bytes32[])" "$subscribers_array" --rpc-url $RPC_URL --private-key $asset_owner_private_key --json)
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+    return $EXIT_CODE 2>/dev/null || exit $EXIT_CODE
+fi
+
+transaction_hash=$(echo $result | jq -r '.transactionHash')
+
+event_sig=$(cast keccak "CreatorFeeClaimedBatch(bytes32[],uint256)")
+log_data=$(echo $result | jq -r --arg sig "$event_sig" '.logs[] | select(.topics[0] == $sig) | .data')
+total_amount=$(cast --to-dec "$log_data")
+total_formatted=$(awk "BEGIN { printf \"%g\", $total_amount / (10 ^ $token_decimals) }")
+
+echo "Asset Address: $asset_address
+Asset ID: $2
+Subscribers:
+$(echo -e "$subscriber_list")Total Claimed: $total_formatted $token_symbol
+Transaction Hash: $transaction_hash"

--- a/scripts/claimRegistryFee.sh
+++ b/scripts/claimRegistryFee.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+source ./scripts/utils.sh
+
+source_environment $1
+if [ $? -eq 0 ]; then
+    shift 1
+fi
+
+registry_index=$1
+asset_id=$(cast keccak "$2")
+subscriber=$3
+registry_owner_private_key=$4
+
+registry_address=$(get_address $registry_index)
+
+asset_address=$(cast call $registry_address "getAsset(bytes32)(address)" $asset_id --rpc-url $RPC_URL --from $(get_wallet_address 0))
+
+token_address=$(cast call $asset_address "getTokenAddress()(address)" --rpc-url $RPC_URL --from $(get_wallet_address 0))
+token_symbol=$(cast call $token_address "symbol()(string)" --rpc-url $RPC_URL | tr -d '"')
+token_decimals=$(cast call $token_address "decimals()(uint8)" --rpc-url $RPC_URL)
+
+result=$(cast send $registry_address "claimRegistryFee(bytes32,bytes32)" $asset_id $subscriber --rpc-url $RPC_URL --private-key $registry_owner_private_key --json)
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+    return $EXIT_CODE 2>/dev/null || exit $EXIT_CODE
+fi
+
+transaction_hash=$(echo $result | jq -r '.transactionHash')
+
+# RegistryFeeClaimed(bytes32 indexed assetId, bytes32 indexed subscriber, uint256 amount, uint256 claimedAtTimestamp, uint256 claimedAtNonce)
+# amount is the first of three non-indexed fields — first 32 bytes (64 hex chars) of data
+event_sig=$(cast keccak "RegistryFeeClaimed(bytes32,bytes32,uint256,uint256,uint256)")
+log_data=$(echo $result | jq -r --arg sig "$event_sig" '.logs[] | select(.topics[0] == $sig) | .data')
+amount_hex="0x${log_data:2:64}"
+claimed_amount=$(cast --to-dec "$amount_hex")
+claimed_formatted=$(awk "BEGIN { printf \"%g\", $claimed_amount / (10 ^ $token_decimals) }")
+
+echo "Asset Registry: $registry_address
+Asset ID: $2
+Subscriber: $subscriber
+Claimed: $claimed_formatted $token_symbol
+Transaction Hash: $transaction_hash"

--- a/scripts/claimRegistryFeeBatch.sh
+++ b/scripts/claimRegistryFeeBatch.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+source ./scripts/utils.sh
+
+source_environment $1
+if [ $? -eq 0 ]; then
+    shift 1
+fi
+
+registry_index=$1
+asset_id=$(cast keccak "$2")
+registry_owner_private_key=$3
+shift 3
+
+subscribers_array="["
+subscriber_list=""
+first=true
+while [ $# -ge 1 ]; do
+    hash=$1
+    shift 1
+    if [ "$first" = true ]; then
+        subscribers_array+="$hash"
+        first=false
+    else
+        subscribers_array+=",$hash"
+    fi
+    subscriber_list+="  $hash\n"
+done
+subscribers_array+="]"
+
+registry_address=$(get_address $registry_index)
+
+asset_address=$(cast call $registry_address "getAsset(bytes32)(address)" $asset_id --rpc-url $RPC_URL --from $(get_wallet_address 0))
+
+token_address=$(cast call $asset_address "getTokenAddress()(address)" --rpc-url $RPC_URL --from $(get_wallet_address 0))
+token_symbol=$(cast call $token_address "symbol()(string)" --rpc-url $RPC_URL | tr -d '"')
+token_decimals=$(cast call $token_address "decimals()(uint8)" --rpc-url $RPC_URL)
+
+result=$(cast send $registry_address "claimRegistryFee(bytes32,bytes32[])" $asset_id "$subscribers_array" --rpc-url $RPC_URL --private-key $registry_owner_private_key --json)
+EXIT_CODE=$?
+
+if [ $EXIT_CODE -ne 0 ]; then
+    return $EXIT_CODE 2>/dev/null || exit $EXIT_CODE
+fi
+
+transaction_hash=$(echo $result | jq -r '.transactionHash')
+
+event_sig=$(cast keccak "RegistryFeeClaimedBatch(bytes32,bytes32[],uint256)")
+log_data=$(echo $result | jq -r --arg sig "$event_sig" '.logs[] | select(.topics[0] == $sig) | .data')
+total_amount=$(cast --to-dec "$log_data")
+total_formatted=$(awk "BEGIN { printf \"%g\", $total_amount / (10 ^ $token_decimals) }")
+
+echo "Asset Registry: $registry_address
+Asset ID: $2
+Subscribers:
+$(echo -e "$subscriber_list")Total Claimed: $total_formatted $token_symbol
+Transaction Hash: $transaction_hash"

--- a/scripts/createAsset.sh
+++ b/scripts/createAsset.sh
@@ -2,6 +2,11 @@
 
 source ./scripts/utils.sh
 
+source_environment $1
+if [ $? -eq 0 ]; then
+    shift 1
+fi
+
 registry_index=$1
 
 asset_id=$(cast keccak "$2")

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -2,6 +2,11 @@
 
 source ./scripts/utils.sh
 
+source_environment $1
+if [ $? -eq 0 ]; then
+    shift 1
+fi
+
 contract_name=$1
 owner_private_key=$2
 

--- a/scripts/deployRegistry.sh
+++ b/scripts/deployRegistry.sh
@@ -2,6 +2,11 @@
 
 source ./scripts/utils.sh
 
+source_environment $1
+if [ $? -eq 0 ]; then
+    shift 1
+fi
+
 registry_fee_share=$1
 registry_owner_private_key=$2
 

--- a/scripts/deployTestToken.sh
+++ b/scripts/deployTestToken.sh
@@ -2,6 +2,11 @@
 
 source ./scripts/utils.sh
 
+source_environment $1
+if [ $? -eq 0 ]; then
+    shift 1
+fi
+
 result=$(./scripts/deploy.sh "TestToken" $(get_private_key 0))
 EXIT_CODE=$?
 

--- a/scripts/mintTestToken.sh
+++ b/scripts/mintTestToken.sh
@@ -2,6 +2,11 @@
 
 source ./scripts/utils.sh
 
+source_environment $1
+if [ $? -eq 0 ]; then
+    shift 1
+fi
+
 token_address=$(get_token_address)
 
 to=$1

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -21,3 +21,6 @@ gh release create "$version" \
   --title "$version" \
   --notes "$notes" \
   deployments/*
+
+git tag "v$version" "$version"
+git push origin "v$version"

--- a/scripts/seed.sh
+++ b/scripts/seed.sh
@@ -15,20 +15,12 @@ cleanup() {
 
 trap cleanup EXIT
 
-environment=$1
-
-if [ -f "$environment" ]; then
-    # shellcheck source=./.env.local
-    source "$PROJECT_ROOT/$environment"
-    
-    if [ "$environment" == ".env.local" ]; then
-        anvil &
-        ANVIL_PID=$!
-        until nc -z -w 1 127.0.0.1 8545; do :; done
-    fi
-fi
-
 source ./scripts/utils.sh
+
+source_environment $1
+if [ $? -eq 0 ]; then
+    shift 1
+fi
 
 ./scripts/deployTestToken.sh
 

--- a/scripts/setSubscriptionPrice.sh
+++ b/scripts/setSubscriptionPrice.sh
@@ -2,6 +2,11 @@
 
 source ./scripts/utils.sh
 
+source_environment $1
+if [ $? -eq 0 ]; then
+    shift 1
+fi
+
 registry_index=$1
 asset_id=$(cast keccak $2)
 new_subscription_price=$3

--- a/scripts/subscribe.sh
+++ b/scripts/subscribe.sh
@@ -2,6 +2,11 @@
 
 source ./scripts/utils.sh
 
+source_environment $1
+if [ $? -eq 0 ]; then
+    shift 1
+fi
+
 registry_index=$1
 asset_id=$(cast keccak "$2")
 subscriber_id=$3

--- a/scripts/transferAssetOwnership.sh
+++ b/scripts/transferAssetOwnership.sh
@@ -2,6 +2,11 @@
 
 source ./scripts/utils.sh
 
+source_environment $1
+if [ $? -eq 0 ]; then
+    shift 1
+fi
+
 registry_index=$1
 asset_id=$(cast keccak $2)
 asset_owner_private_key=$3

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -79,5 +79,5 @@ function encode_subscriber() {
     subscriber_id=$1
     subscriber_address=$2
 
-    echo $(cast abi-encode "f(string,address)" "$subscriber_id" "$subscriber_address")
+    echo $(cast keccak "$(cast abi-encode "f(string,address)" "$subscriber_id" "$subscriber_address")")
 }

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -50,3 +50,34 @@ function get_token_address() {
     result=$(jq -r ".[\"$chain_id\"]" "$file_name")
     echo $result
 }
+
+function source_environment() {
+    if [ ! $SOURCE_SCRIPT ]; then
+        
+        environment=$1
+    
+        if [ -f "$environment" ]; then
+            # shellcheck source=./.env.local
+            source "$PROJECT_ROOT/$environment"
+
+            if [ "$environment" == ".env.local" ]; then
+                anvil &
+                ANVIL_PID=$!
+                until nc -z -w 1 127.0.0.1 8545; do :; done
+            fi
+
+            export SOURCE_SCRIPT=true
+
+            return 0
+        fi
+    else
+        return 1
+    fi
+}
+
+function encode_subscriber() {
+    subscriber_id=$1
+    subscriber_address=$2
+
+    echo $(cast abi-encode "f(string,address)" "$subscriber_id" "$subscriber_address")
+}


### PR DESCRIPTION
## Summary

- Add shell scripts to cancel subscriptions and claim creator/registry fees (single and batch).
- Extend `scripts/utils.sh` with shared helpers used across deployment and interaction scripts.
- Document the new scripts and secondary release tags in the README; wire existing scripts to the shared utilities.

## Test plan

- [ ] Run `cancelSubscription.sh` against a local or testnet deployment with an active subscription
- [ ] Run `claimCreatorFee.sh` / `claimRegistryFee.sh` for a single asset after fees accrue
- [ ] Run `claimCreatorFeeBatch.sh` / `claimRegistryFeeBatch.sh` with multiple asset IDs
- [ ] Verify `release.sh` secondary tag behavior matches README
- [ ] Confirm existing scripts (`subscribe.sh`, `seed.sh`, etc.) still work with updated `utils.sh`


Made with [Cursor](https://cursor.com)